### PR TITLE
feat(index): disable jsx-one-expression-per-line

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,6 +161,9 @@ module.exports = {
 
     // React fragment syntax requires Babel 7.x but this preset needs to still support Babel 6.x
     'react/jsx-fragments': 'off',
+    // Disabling this rule until this is resolved https://github.com/yannickcr/eslint-plugin-react/issues/1848
+    // at the moment the fix makes the code look messy and at times unreadable
+    'react/jsx-one-expression-per-line': 'off',
   },
   overrides: [{
     // Certain rules need to be disabled when we are linting markdown files,


### PR DESCRIPTION
At the moment this rule ```jsx-one-expression-per-line``` would change this

 ```<div>{x} * {y} = {xy}</div>```

to this 

```
 <div>
        {x}
        {' '}
*
        {y}
        {' '}
=
        {' '}
        {xy}
      </div>
```
which makes it messy and unreadable. Until this is resolved https://github.com/yannickcr/eslint-plugin-react/issues/1848. Im proposing we disable this rule

