### PR TITLE
feat(rules): no-extra-parens

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,6 +161,9 @@ module.exports = {
 
     // React fragment syntax requires Babel 7.x but this preset needs to still support Babel 6.x
     'react/jsx-fragments': 'off',
+
+    // This rule restricts the use of parentheses to only where they are necessary.
+    'no-extra-parens': 'error',
   },
   overrides: [{
     // Certain rules need to be disabled when we are linting markdown files,


### PR DESCRIPTION
When my .eslintrc file is this:
```
{
  "extends": "amex"
}
```

The following code does not trigger any warnings / errors:
```
      if (!(((((child.data)))))) {
        return child.children.map((c) => c.data);
      }
```

However including that extra rule directly via
```
{
  "extends": "amex",
  "rules": {
    "no-extra-parens": "error"
  }
}
```

makes the error appear:
![image](https://user-images.githubusercontent.com/967811/73453894-f709cc00-433a-11ea-93b2-c70fcd1d3746.png)
