### PR TITLE
feat(eslint): alphanumeric sorting

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = {
     'unicorn',
     'react-hooks',
     'you-dont-need-lodash-underscore',
+    'sort-destructure-keys',
   ],
   rules: {
     // open a PR per rule change
@@ -126,6 +127,37 @@ module.exports = {
     // or nested functions
     // https://reactjs.org/docs/hooks-rules.html#eslint-plugin
     'react-hooks/rules-of-hooks': 'error',
+
+    // Alphabetical sorting is the most reliable way to make code consistently readable
+    // This goes for imports, props, objects, etc.
+    // https://eslint.org/docs/rules/sort-imports
+    'sort-imports': [
+      // This one is warn so it isn't disruptive during development
+      'warn',
+      {
+        ignoreCase: true,
+        memberSyntaxSortOrder: ['multiple', 'single', 'all', 'none'],
+      },
+    ],
+
+    // This enforces props are alphabetical on <Components />
+    // Reserved props should be sorted first (key, ref, etc.)
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
+    'react/jsx-sort-props': [
+      'error',
+      {
+        ignoreCase: true,
+        reservedFirst: true,
+      },
+    ],
+
+    // This ensures deconstructed props/state, etc. are alphabetical
+    // https://github.com/mthadley/eslint-plugin-sort-destructure-keys
+    'sort-destructure-keys/sort-destructure-keys': 'error',
+
+    // Use the sort-imports rule instead
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
+    'import/order': 'off',
 
     // Forbid the use of extraneous packages
     'import/no-extraneous-dependencies': ['error', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3695,6 +3695,14 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.1.tgz",
       "integrity": "sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g=="
     },
+    "eslint-plugin-sort-destructure-keys": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-destructure-keys/-/eslint-plugin-sort-destructure-keys-1.3.4.tgz",
+      "integrity": "sha512-isdXh0LxE6WEUkkmNtpXX0W95wqCyYI6PY3w9aEcrWQ2IqUzgHQpCfMcb8BD5Wlp2Y9i91kk2leDiII43C1kww==",
+      "requires": {
+        "natural-compare-lite": "^1.4.0"
+      }
+    },
     "eslint-plugin-unicorn": {
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-18.0.0.tgz",
@@ -6583,6 +6591,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha1-F7CVgZiJef3a/gIB6TG6kzyWy7Q="
     },
     "neo-async": {
       "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-markdown": "^1.0.2",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^2.5.1",
+    "eslint-plugin-sort-destructure-keys": "^1.3.4",
     "eslint-plugin-unicorn": "^18.0.0",
     "eslint-plugin-you-dont-need-lodash-underscore": "^6.10.0",
     "estraverse-fb": "^1.3.2",


### PR DESCRIPTION
Alphanumeric sorting of imports, PropTypes, Component props in JSX, and destructured props.

I'd like to talk about what I think is a very important change and uses a few rules to accomplish and that is alphanumeric sorting throughout.

Every developer has a different idea about what a "logical group" is. I used to group my props by what I thought made logical sense. However, even that thought process evolves, and I found myself looking back at old code and reordering props to match my more recent opinion about it. This created a lot of fragmentation over time.

There's one logical grouping that everyone knows instinctively, and that is alphanumeric. There's no debating it. It's not a matter of opinion that the letter B comes before the letter P, or that 4 is greater than 2. We don't have to think about it. It's automatic.

Alphanumerically sorting imports, props, destructured object properties, (and react hook dependency arrays) results in everything being super easy to find when looking at your and other people's code because it's sorted by a pattern that we all agree on without thinking. The great news is that with the exception of the import sorting rule, the sorting rules are all --fix-able.