### PR TITLE
fix(eslint): allow nested ternaries

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,12 @@ module.exports = {
     // regular expressions.
     'unicorn/no-unsafe-regex': 'error',
 
+    // Nested ternaries are commonly used in JSX
+    // https://eslint.org/docs/rules/no-nested-ternary
+    'no-nested-ternary': 'off',
+    // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-nested-ternary.md
+    'unicorn/no-nested-ternary': 'off',
+
     // Functions that take many positional arguments can be difficult to work
     // with and produce less maintainable APIs. When more than three arguments
     // are needed, named arguments should be used.


### PR DESCRIPTION
JSX uses nested ternaries.

Another thing to consider is if we use Prettier, Prettier makes nested ternaries a lot nicer looking.