### PR TITLE
fix(eslint): disable airbnb default props rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,7 +180,7 @@ module.exports = {
     // at the moment the fix makes the code look messy and at times unreadable
     'react/jsx-one-expression-per-line': 'off',
 
-    // tests are more reliable, reduce unnecessary boilerplate explicitly setting props to `undefined`, 
+    // reduces the unnecessary boilerplate of explicitly setting props to `undefined`
     // prevent false-confidence for those less experienced with how default props work
     'react/require-default-props': 'off',
   },

--- a/index.js
+++ b/index.js
@@ -169,9 +169,8 @@ module.exports = {
     // at the moment the fix makes the code look messy and at times unreadable
     'react/jsx-one-expression-per-line': 'off',
 
-    // The only thing these AirBnB-enabled rules do is create unnecessary boilerplate
+    // Disabling this AirBnB-enabled rule because it creates unnecessary boilerplate
     'react/require-default-props': 'off',
-    'react/default-props-match-prop-types': 'off',
   },
   overrides: [{
     // Certain rules need to be disabled when we are linting markdown files,

--- a/index.js
+++ b/index.js
@@ -180,7 +180,8 @@ module.exports = {
     // at the moment the fix makes the code look messy and at times unreadable
     'react/jsx-one-expression-per-line': 'off',
 
-    // Disabling this AirBnB-enabled rule because it creates unnecessary boilerplate
+    // tests are more reliable, reduce unnecessary boilerplate explicitly setting props to `undefined`, 
+    // prevent false-confidence for those less experienced with how default props work
     'react/require-default-props': 'off',
   },
   overrides: [{

--- a/index.js
+++ b/index.js
@@ -168,6 +168,10 @@ module.exports = {
     // Disabling this rule until this is resolved https://github.com/yannickcr/eslint-plugin-react/issues/1848
     // at the moment the fix makes the code look messy and at times unreadable
     'react/jsx-one-expression-per-line': 'off',
+
+    // The only thing these AirBnB-enabled rules do is create unnecessary boilerplate
+    'react/require-default-props': 'off',
+    'react/default-props-match-prop-types': 'off',
   },
   overrides: [{
     // Certain rules need to be disabled when we are linting markdown files,


### PR DESCRIPTION
I am fundamentally opposed to these rules which are inherited from AirBnB. We can discuss it, but I have very good reasons why I am against them.

They require writing more code, not less. They give developers who don't truly understand how default props work false confidence. They are primarily beneficial when writing a library of components for public consumption, but are far too burdensome when writing regular components inside of a typical application. If you're writing a library for public consumption, tests are far more reliable than this burdensome rule.

The implied value of any undefined variable in JavaScript is undefined. We don't need to declare that as the default value. And that's what these rules end up doing. Every code base I have seen with these rules enabled is full of noise where props are being explicitly set to undefined, even though that's what the value of any undefined variable is.