### PR TITLE
fix(eslint): disable prevent abbreviations

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,11 @@ module.exports = {
     // regular expressions.
     'unicorn/no-unsafe-regex': 'error',
 
+    // Preventing abbreviations is incompatible with React standards (props, ref, etc.)
+    // Additionally, there are many scenarios where abbreviations are acceptable
+    // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prevent-abbreviations.md
+    'unicorn/prevent-abbreviations': 'off',
+
     // Functions that take many positional arguments can be difficult to work
     // with and produce less maintainable APIs. When more than three arguments
     // are needed, named arguments should be used.

--- a/index.js
+++ b/index.js
@@ -117,7 +117,8 @@ module.exports = {
     'unicorn/no-unsafe-regex': 'error',
 
     // Preventing abbreviations is incompatible with React standards (props, ref, etc.)
-    // Additionally, there are many scenarios where abbreviations are acceptable
+    // Additionally, there are many popular libraries that have abbreviations
+    // as their standard practice and this rule prevents that consistency
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prevent-abbreviations.md
     'unicorn/prevent-abbreviations': 'off',
 


### PR DESCRIPTION
Preventing abbreviations is incompatible with React standards (props, ref, etc.). Additionally, there are many scenarios where abbreviations are acceptable.

In the future, we may decide to make a whitelist, but since that will take time to decide and this rule is currently in the published ruleset, we are releasing it with the rule disabled for now to address this problem quickly.