### PR TITLE
feat(eslint): array includes is acceptable

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,9 @@ module.exports = {
     'unicorn/no-unsafe-regex': 'error',
 
     // Array.includes() is consistent with String.includes()
-    // Whatever minor performance increase this might have is a premature optimization, at best
+    // the rule's performance claim is unsubstantiated and appears to be premature optimization
+    // https://github.com/sindresorhus/eslint-plugin-unicorn/issues/495 and
+    // https://github.com/sindresorhus/eslint-plugin-unicorn/issues/604
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-set-has.md
     'unicorn/prefer-set-has': 'off',
 

--- a/index.js
+++ b/index.js
@@ -105,6 +105,11 @@ module.exports = {
     // regular expressions.
     'unicorn/no-unsafe-regex': 'error',
 
+    // Array.includes() is consistent with String.includes()
+    // Whatever minor performance increase this might have is a premature optimization, at best
+    // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-set-has.md
+    'unicorn/prefer-set-has': 'off',
+
     // Functions that take many positional arguments can be difficult to work
     // with and produce less maintainable APIs. When more than three arguments
     // are needed, named arguments should be used.


### PR DESCRIPTION
This is a questionable rule. As stated in the comment above the rule, Array.includes() is a consistent api with String.includes(). Further, any alleged performance increase is almost assuredly imperceptible in most cases and is thus a premature optimization.