### PR TITLE
feat(eslint): disable function scoping

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,9 +116,8 @@ module.exports = {
     // regular expressions.
     'unicorn/no-unsafe-regex': 'error',
 
-    // This is a common pattern in React, and has been proven to be a premature optimization
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/consistent-function-scoping.md
-    'unicorn/consistent-function-scoping': 'off',
+    'unicorn/consistent-function-scoping': 'warn',
 
     // Preventing abbreviations is incompatible with React standards (props, ref, etc.)
     // Additionally, there are many popular libraries that have abbreviations

--- a/index.js
+++ b/index.js
@@ -105,6 +105,10 @@ module.exports = {
     // regular expressions.
     'unicorn/no-unsafe-regex': 'error',
 
+    // This is a common pattern in React, and has been proven to be a premature optimization
+    // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/consistent-function-scoping.md
+    'unicorn/consistent-function-scoping': 'off',
+
     // Functions that take many positional arguments can be difficult to work
     // with and produce less maintainable APIs. When more than three arguments
     // are needed, named arguments should be used.


### PR DESCRIPTION
This is a common pattern in React. The source of the measurements used as the basis for this rule were found to have been taken in the development version of React and were disproven. However, the myth persists. The React team has stated that this optimization is not necessary.