### PR TITLE
feat(unicorn/prefer-includes): disable

### DIFF
--- a/unicorn.js
+++ b/unicorn.js
@@ -114,9 +114,10 @@ module.exports = {
     // TODO: Enable this by default when targeting Node.js 12.
     'unicorn/prefer-flat-map': 'off',
 
-    // Prefer .includes() over .indexOf() when checking for existence or non-existence
+    // Don't prefer .includes() over .indexOf() when checking for existence or non-existence.
+    // Internet Explorer does not support .includes()
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-includes.md
-    'unicorn/prefer-includes': 'error',
+    'unicorn/prefer-includes': 'off',
 
     // Prefer modern DOM APIs
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-modern-dom-apis.md


### PR DESCRIPTION
Disabling this rule as Internet Explorer does not have support for `.includes()`.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes