### PR TITLE
feat(test): whitelist 'props' for unicorn/prevent-abbreviations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-amex",
-  "version": "13.1.0",
+  "version": "13.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-amex",
-  "version": "13.1.0",
+  "version": "13.2.0",
   "description": "American Express' ESLint config",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -47,5 +47,7 @@ module.exports = {
     'react/jsx-props-no-spreading': 0,
     // this conflicts with co-located tests
     'unicorn/import-index': 'off',
+    // the word "props" has a distinct meaning in React, beyond being shorthand for "properties"
+    'unicorn/prevent-abbreviations': ['error', { whitelist: { props: true, Props: true } }],
   },
 };


### PR DESCRIPTION
This PR allows developers to use variable names with `props` or `Props` in the name when writing test cases. The word "props" has deeper meaning in React beyond merely shorthand for "properties", and so referring to "props" as "properties" can actually make code less readable.

## Description

Extends the "unicorn/prevent-abbreviations" rule to whitelist "props" and "Props"

Please make sure that the PR fulfills these requirements

- [X] I checked that there aren't other open Pull Requests for the same update/change.
- [X] My code follows the code style of this project.
- [N/A] My change requires a change to the documentation and I have updated the documentation accordingly.
- [X] Rule changes includes a comment to describe the reasoning behind the change.
- [X] PR contains a single rule change.
    
## Motivation and Context

When writing test cases, it's often useful to declare "props" variables for spreading into React components. They cut down on noise when changing only one or two for a particular test case.

React components have a "props vs state" dichotomy that creates a distinct meaning for the word props, which can be confusing to React developers if you expand the word out to "properties"

## How Has This Been Tested?

Tested through manually whitelisting the rule in modules that were on earlier versions of `eslint-config-amex`. Since this is a whitelist change, it will be backwards-compatible.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
