### PR TITLE
feat(react/boolean-prop-naming): extend to allow 'should' in boolean …

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ module.exports = {
       'error',
       {
         propTypeNames: ['bool', 'mutuallyExclusiveTrueProps'],
-        rule: '^((is|has|can|show|hide)[A-Z]([A-Za-z0-9]?)+|(show|hide))',
+        rule: '^((is|has|can|show|hide|should)[A-Z]([A-Za-z0-9]?)+|(show|hide))',
       },
     ],
 


### PR DESCRIPTION
…names

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Please make sure that the PR fulfills these requirements
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] Rule changes includes a comment to describe the reasoning behind the change.
- [x] PR contains a single rule change.
    
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The word `should` allows for clear naming of boolean variables with bearing on actions to take ie `shouldApprovePullRequest` (true 😛)
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
