### PR TITLE
feat(eslint-comments): aid maintainability of eslint directives

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -16,8 +16,8 @@ describe('index.js', () => {
   it('should be import/require-able', () => {
     let configImportable = true;
     try {
-      // require is part of the test
-      require('..'); // eslint-disable-line global-require
+      // eslint-disable-next-line global-require -- require is part of the test
+      require('..');
     } catch (error) {
       configImportable = false;
     }

--- a/__tests__/prettier/index.spec.js
+++ b/__tests__/prettier/index.spec.js
@@ -16,8 +16,8 @@ describe('prettier.js', () => {
   it('should be import/require-able', () => {
     let configImportable = true;
     try {
-      // require is part of the test
-      require('../../prettier/index.js'); // eslint-disable-line global-require
+      // eslint-disable-next-line global-require -- require is part of the test
+      require('../../prettier/index.js');
     } catch {
       configImportable = false;
     }

--- a/__tests__/prettier/test.spec.js
+++ b/__tests__/prettier/test.spec.js
@@ -16,8 +16,8 @@ describe('prettier.js', () => {
   it('should be import/require-able', () => {
     let configImportable = true;
     try {
-      // require is part of the test
-      require('../../prettier/test.js'); // eslint-disable-line global-require
+      // eslint-disable-next-line global-require -- require is part of the test
+      require('../../prettier/test.js');
     } catch {
       configImportable = false;
     }

--- a/__tests__/test.spec.js
+++ b/__tests__/test.spec.js
@@ -16,8 +16,8 @@ describe('test.js', () => {
   it('should be import/require-able', () => {
     let configImportable = true;
     try {
-      // require is part of the test
-      require('../test.js'); // eslint-disable-line global-require
+      // eslint-disable-next-line global-require -- require is part of the test
+      require('../test.js');
     } catch (error) {
       configImportable = false;
     }

--- a/__tests__/unicorn.js
+++ b/__tests__/unicorn.js
@@ -16,8 +16,8 @@ describe('unicorn.js', () => {
   it('should be import/require-able', () => {
     let configImportable = true;
     try {
-      // require is part of the test
-      require('../unicorn'); // eslint-disable-line global-require
+      // eslint-disable-next-line global-require -- require is part of the test
+      require('../unicorn');
     } catch (error) {
       configImportable = false;
     }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable inclusive-language/use-inclusive-words */
 /*
  * Copyright (c) 2017 American Express Travel Related Services Company, Inc.
  *
@@ -231,6 +230,8 @@ module.exports = {
     'react/require-default-props': 'off',
 
     // encourage the use of inclusive language
+    /* eslint-disable inclusive-language/use-inclusive-words
+    -- The following config lists noninclusive words: */
     'inclusive-language/use-inclusive-words': [
       'warn',
       {
@@ -255,6 +256,7 @@ module.exports = {
         lintStrings: true,
       },
     ],
+    /* eslint-enable inclusive-language/use-inclusive-words -- Check for noninclusive words */
   },
   overrides: [{
     // Certain rules need to be disabled when we are linting markdown files,

--- a/index.js
+++ b/index.js
@@ -33,6 +33,8 @@ module.exports = {
     'eslint-config-airbnb',
     './unicorn',
   ].map(require.resolve).concat([
+    // aid maintainability of eslint directives (usually overrides)
+    'plugin:eslint-comments/recommended',
     // Helpful rules for writing React
     'plugin:react/recommended',
     // Use native JS instead of lodash
@@ -53,6 +55,7 @@ module.exports = {
     },
   },
   plugins: [
+    'eslint-comments',
     'import',
     'inclusive-language',
     'jsx-a11y',
@@ -63,6 +66,11 @@ module.exports = {
   ],
   rules: {
     // open a PR per rule change
+
+    // record why the directive is seen to be justified
+    'eslint-comments/require-description': ['error'],
+    // remove out of date directives, ensure the directive is used where it should be
+    'eslint-comments/no-unused-disable': ['error'],
 
     // Simplifies code and reduces bugs
     // https://eslint.org/docs/rules/no-lonely-if

--- a/package-lock.json
+++ b/package-lock.json
@@ -3735,6 +3735,15 @@
         }
       }
     },
+    "eslint-plugin-eslint-comments": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.22.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
@@ -4982,8 +4991,7 @@
     "ignore": {
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-      "dev": true
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
     },
     "import-fresh": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-eslint": "^10.1.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-prettier": "^7.0.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-inclusive-language": "^2.1.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",


### PR DESCRIPTION
[eslint-plugin-eslint-comments](https://www.npmjs.com/package/eslint-plugin-eslint-comments)
BREAKING CHANGE: [7 new rules](https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules) added as errors

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Please make sure that the PR fulfills these requirements
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] Rule changes includes a comment to describe the reasoning behind the change.
- [ ] PR contains a single rule change.
    
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Usually eslint directives are overrides of a preset or project-level configuration. There are situations where an override may be the best path. This plugin helps those instances to be applied to the right location, record the reasoning behind the override, prevent unintended side-effects (ex: applying to more locations by forgetting to re-enable the rule), and remove unused rule violation overrides.

Most visible to developers will be [eslint-comments/require-description](https://github.com/mysticatea/eslint-plugin-eslint-comments/blob/master/docs/rules/require-description.md). This uses the [description-in-directive-comments RFC](https://github.com/eslint/rfcs/blob/master/designs/2019-description-in-directive-comments/README.md) to require a description on the eslint directive. Practically, this means instead of
```javascript
// description on why this exception is seen as appropriate
// eslint-disable-next-line global-require
const fizz = require(buzz);
```
developers can use
```javascript
// eslint-disable-next-line global-require -- description on why this exception is seen as appropriate
const fizz = require(buzz);
```
This formalization also enables other tooling in the future, ex: generating a list of reasons preset overrides are used in a project (many uses, notably assessing if a certain rule is becoming troublesome). 

Other rules from the plugin but not enabled by this PR are [`eslint-comments/no-use`](https://github.com/mysticatea/eslint-plugin-eslint-comments/blob/master/docs/rules/no-use.md) and [`eslint-comments/no-restricted-disable`](https://github.com/mysticatea/eslint-plugin-eslint-comments/blob/master/docs/rules/no-restricted-disable.md). These would be tricky to configure well for multiple projects and would probably encourage developers to disable the preset entirely.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've `$ npm pack`'d and `$ npm install`'d this change in another project and saw the only changes needed were to remove unused directives and editing the other directives to move the comments to the formal format.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

If these rules are desirable in this preset I can open another PR to also add them as warnings for usage in the current major version.