### PR TITLE
feat: remove Node v10 support and add support for Node v16

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '10.x', '12.x', '14.x' ]
+        node: [ '12.x', '14.x', '16.x' ]
     name: Node ${{ matrix.node }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '10.x', '12.x', '14.x' ]
+        node: [ '12.x', '14.x', '16.x' ]
     name: Node ${{ matrix.node }}
     steps:
     - uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ Provide the system information which is not limited to the below:
 
 - OS: [e.g. macOS, Windows]
 - Version of eslint-config-amex: [e.g. 5.0.0]
-- Node version:[e.g 10.15.1]
+- Node version:[e.g 14.17.0]
 
 ### Security Bugs
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "eslint",
     "eslintconfig"
   ],
+  "engines": {
+    "node": ">= 12.0.0"
+  },
   "dependencies": {
     "babel-eslint": "^10.1.0",
     "eslint-config-airbnb": "^18.2.1",


### PR DESCRIPTION
BREAKING CHANGE: Node v10 has reached end-of-life and is no longer supported.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed Node v10 from CI, added Node v16 to CI, added `engines` property to `package.json` with support for Node v12 and later.

Please make sure that the PR fulfills these requirements
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I checked that there aren't other open Pull Requests for the same update/change.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] Rule changes includes a comment to describe the reasoning behind the change.
- [ ] PR contains a single rule change.
    
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Node v10 reached end-of-life on April 30th, 2021.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
`npm install` followed by `npm test` in Node v16.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [X] Dependency update
