### PR TITLE
feat(ally): disallow nesting of controls in labels

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,6 +134,7 @@ module.exports = {
 
     // Nesting controls inside of label has poor support in assistive technologies,
     // instead enforce separate tags with an htmlFor on the label.
+    // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md
     'jsx-a11y/label-has-associated-control': ['error', {
       assert: 'htmlFor',
     }],

--- a/index.js
+++ b/index.js
@@ -132,6 +132,12 @@ module.exports = {
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/455#issuecomment-403359963
     'jsx-a11y/label-has-for': 'off',
 
+    // Nesting controls inside of label has poor support in assistive technologies,
+    // instead enforce separate tags with an htmlFor on the label.
+    'jsx-a11y/label-has-associated-control': ['error', {
+      assert: 'htmlFor',
+    }],
+
     // this rule isn't ready yet
     // arrow functions are forced to put the return values on a new line, rather than inline
     // with the argument and fat arrow itself, which is awkward syntax


### PR DESCRIPTION
Nesting controls inside of label has poor support in assistive technologies, instead enforce separate tags with an htmlFor on the label.

Please make sure that the PR fulfills these requirements
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] Rule changes includes a comment to describe the reasoning behind the change.
- [x] PR contains a single rule change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
