### PR TITLE
feat: treat vite config files as dev files

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,6 +214,8 @@ module.exports = {
         // additional paths used only in development
         'dev.*.js', // developer config
         'mock/**', // parrot mocks
+        '**/vite.config.{ts,js}', // vite config
+        '**/vitest.config.{ts,js}', // vitest config
       ],
       optionalDependencies: false,
     }],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Marks the vite / vitest config files as development files so that the `import/no-extraneous-dependencies` rule works properly.
    
## Motivation and Context
Without this, eslint throws an error saying any imports they use should be added to dependencies not devDependencies.

## How Has This Been Tested?
Packed and installed in a repo using vitest.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
