### PR TITLE
feat: support typescript extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,15 +189,15 @@ module.exports = {
     // Forbid the use of extraneous packages
     'import/no-extraneous-dependencies': ['error', {
       devDependencies: [
-        // base list from airbnb config
+        // base list from airbnb config + typescript extensions
         'test/**', // tape, common npm pattern
         'tests/**', // also common npm pattern
         'spec/**', // mocha, rspec-like pattern
         '**/__tests__/**', // jest pattern
         '**/__mocks__/**', // jest pattern
-        'test.{js,jsx}', // repos with a single test file
-        'test-*.{js,jsx}', // repos with multiple top-level test files
-        '**/*{.,_}{test,spec}.{js,jsx}', // tests where the extension or filename suffix denotes that it is a test
+        'test.{js,jsx,ts,tsx}', // repos with a single test file
+        'test-*.{js,jsx,ts,tsx}', // repos with multiple top-level test files
+        '**/*{.,_}{test,spec}.{js,jsx,ts,tsx}', // tests where the extension or filename suffix denotes that it is a test
         '**/jest.config.js', // jest config
         '**/jest.setup.js', // jest setup
         '**/vue.config.js', // vue-cli config


### PR DESCRIPTION
## Description

For `import/no-extraneous-dependencies` rule, support both typescript and javascript extensions.

## Motivation and Context

For the purposes of this rule, typescript vs javascript is not relevant and both should be supported.

## How Has This Been Tested?
Packed and installed in repo using this ruleset and verified resolves error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
