### PR TITLE
chore(workflows): remove scheduled CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    # At minute 0 past hour 0800 and 2000.
-    - cron:  '0 8,20 * * *'
 
 jobs:
   commitlint:


### PR DESCRIPTION
## Description
Github disables scheduled workflows after 60 days of inactivity.  Since this workflow is both the PR check workflow and scheduled, this effectively means PR checks are disabled after 60 days of inactivity until an admin re-enables them.

This seems annoying enough that it's not worth having the scheduled runs. 