### PR TITLE
feat: support mocks dir as dev directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ module.exports = {
 
         // additional paths used only in development
         'dev.*.js', // developer config
-        'mock/**', // parrot mocks
+        'mock{,s}/**', // parrot mocks
         '**/vite.config.{ts,js}', // vite config
         '**/vitest.config.{ts,js}', // vitest config
       ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Please make sure that the PR fulfills these requirements
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] Rule changes includes a comment to describe the reasoning behind the change.
- [ ] PR contains a single rule change.
    
## Motivation and Context
We support `__mocks__` and `mock` but not `mocks` as dev directories.

People who run into this rule tend to just install the dependencies as non-dev, which isn't good.

## How Has This Been Tested?
Verified that released version triggered `import/no-extraneous-dependencies` for `mocks` dir.
Verified that PR version did not trigger rule for `mocks` dir.
Verified that PR version did not trigger rule for `mock` or `__mocks__` (regression).
Verified that PR version did trigger for `foo` dir (regression).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
