### PR TITLE
fix(deps): use semver for @babel/eslint-parser

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "16.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/eslint-parser": "7.16.5",
+        "@babel/eslint-parser": "^7.25.9",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
@@ -133,20 +133,21 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.5.tgz",
-      "integrity": "sha512-mUqYa46lgWqHKQ33Q6LNCGp/wPR3eqOYTUixHFsfrSQqRxH0+WOzca75iEjFr5RDGH1dDz622LaHhLOzOuQRUA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.9.tgz",
+      "integrity": "sha512-5UXfgpK0j0Xr/xIdgdLEhOFxaDZ0bRPWJJchRpqOSur/3rZoPbqqki5mm0p4NE2cs28krBEiSM2MB7//afRSQQ==",
+      "license": "MIT",
       "dependencies": {
-        "eslint-scope": "^5.1.1",
+        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
       },
       "peerDependencies": {
-        "@babel/core": ">=7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0"
+        "@babel/core": "^7.11.0",
+        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
       }
     },
     "node_modules/@babel/generator": {
@@ -2316,6 +2317,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
+      "version": "5.1.1-v1",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
+      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
+      "license": "MIT",
+      "dependencies": {
+        "eslint-scope": "5.1.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node": ">= 12.0.0"
   },
   "dependencies": {
-    "@babel/eslint-parser": "7.16.5",
+    "@babel/eslint-parser": "^7.25.9",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-eslint-comments": "^3.2.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use a semver range for @babel/eslint-parser.

Please make sure that the PR fulfills these requirements
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] Rule changes includes a comment to describe the reasoning behind the change.
- [ ] PR contains a single rule change.
    
## Motivation and Context
When this was added in https://github.com/americanexpress/eslint-config-amex/pull/94, a fixed version was used rather than a semver.  There is no rationale for this in the PR, so I assume this was a mistake.

As a result, every consuming package has a fixed version:
```
$ npm ls @babel/eslint-parser
...
└─┬ eslint-config-amex@16.5.0
  └── @babel/eslint-parser@7.16.5
```

@babel/eslint-parser@7.24.5 is required to support eslint@9 so this is part of #132 

## How Has This Been Tested?

Packed and verified version in consumers is no longer fixed.
```
$ npm ls @babel/eslint-parser
...
└─┬ eslint-config-amex@16.5.0
  └── @babel/eslint-parser@7.25.9
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
