### PR TITLE
chore: add .npmrc pointing to default registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds an `.npmrc` file that points to the default npm registry.
    
## Motivation and Context
Ensures that default registry is used for package-lock.json rather than private mirror registries.

## How Has This Been Tested?
Verified it works as expected.