### PR TITLE
ci(release): use trusted publisher, update related deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ jobs:
     needs: prepare
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for trusted publisher publishing
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -38,5 +43,4 @@ jobs:
           GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMITTER_NAME }}
           GITHUB_TOKEN: ${{ secrets.PA_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@commitlint/cli": "^19.3.0",
         "@commitlint/config-conventional": "^19.2.2",
         "@semantic-release/changelog": "^6.0.3",
-        "@semantic-release/commit-analyzer": "^12.0.0",
+        "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/git": "^10.0.1",
         "ajv": "^8.14.0",
         "amex-jest-preset": "^7.0.0",
@@ -39,7 +39,7 @@
         "jest": "^29.7.0",
         "lockfile-lint": "^4.13.2",
         "prettier": "^3.2.5",
-        "semantic-release": "^25.0.2",
+        "semantic-release": "^25.0.3",
         "typescript": "^5.4.5"
       },
       "engines": {
@@ -2638,16 +2638,18 @@
       }
     },
     "node_modules/@semantic-release/commit-analyzer": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-12.0.0.tgz",
-      "integrity": "sha512-qG+md5gdes+xa8zP7lIo1fWE17zRdO8yMCaxh9lyL65TQleoSv8WHHOqRURfghTytUh+NpkSyBprQ5hrkxOKVQ==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.1.tgz",
+      "integrity": "sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "conventional-changelog-angular": "^7.0.0",
-        "conventional-commits-filter": "^4.0.0",
-        "conventional-commits-parser": "^5.0.0",
+        "conventional-changelog-angular": "^8.0.0",
+        "conventional-changelog-writer": "^8.0.0",
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.0.0",
         "debug": "^4.0.0",
-        "import-from-esm": "^1.0.3",
+        "import-from-esm": "^2.0.0",
         "lodash-es": "^4.17.21",
         "micromatch": "^4.0.2"
       },
@@ -2656,6 +2658,49 @@
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
+      }
+    },
+    "node_modules/@semantic-release/commit-analyzer/node_modules/conventional-changelog-angular": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.0.tgz",
+      "integrity": "sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/commit-analyzer/node_modules/conventional-commits-parser": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.3.0.tgz",
+      "integrity": "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/commit-analyzer/node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/error": {
@@ -3194,16 +3239,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-commits-filter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-commits-parser": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.1.tgz",
@@ -3233,20 +3268,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@semantic-release/release-notes-generator/node_modules/import-from-esm": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-2.0.0.tgz",
-      "integrity": "sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "import-meta-resolve": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18.20"
-      }
-    },
     "node_modules/@semantic-release/release-notes-generator/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -3258,6 +3279,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -4634,16 +4668,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/conventional-changelog-writer/node_modules/conventional-commits-filter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/conventional-changelog-writer/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -4671,12 +4695,13 @@
       }
     },
     "node_modules/conventional-commits-filter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
-      "integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-commits-parser": {
@@ -6963,16 +6988,17 @@
       }
     },
     "node_modules/import-from-esm": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.4.tgz",
-      "integrity": "sha512-7EyUlPFC0HOlBDpUFGfYstsU7XHxZJKAAMzCT8wZ0hMW7b+hG51LIKTDcsgtz8Pu6YC0HqRVbX+rVUtsGMUKvg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-2.0.0.tgz",
+      "integrity": "sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
         "import-meta-resolve": "^4.0.0"
       },
       "engines": {
-        "node": ">=16.20"
+        "node": ">=18.20"
       }
     },
     "node_modules/import-local": {
@@ -13546,9 +13572,9 @@
       }
     },
     "node_modules/semantic-release": {
-      "version": "25.0.2",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.2.tgz",
-      "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.3.tgz",
+      "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13578,7 +13604,6 @@
         "read-package-up": "^12.0.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.3.2",
-        "semver-diff": "^5.0.0",
         "signale": "^1.2.1",
         "yargs": "^18.0.0"
       },
@@ -13587,29 +13612,6 @@
       },
       "engines": {
         "node": "^22.14.0 || >= 24.10.0"
-      }
-    },
-    "node_modules/semantic-release/node_modules/@semantic-release/commit-analyzer": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.1.tgz",
-      "integrity": "sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "conventional-changelog-angular": "^8.0.0",
-        "conventional-changelog-writer": "^8.0.0",
-        "conventional-commits-filter": "^5.0.0",
-        "conventional-commits-parser": "^6.0.0",
-        "debug": "^4.0.0",
-        "import-from-esm": "^2.0.0",
-        "lodash-es": "^4.17.21",
-        "micromatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=20.8.1"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=20.1.0"
       }
     },
     "node_modules/semantic-release/node_modules/@semantic-release/error": {
@@ -13691,45 +13693,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/semantic-release/node_modules/conventional-changelog-angular": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.1.0.tgz",
-      "integrity": "sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/semantic-release/node_modules/conventional-commits-filter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/semantic-release/node_modules/conventional-commits-parser": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.1.tgz",
-      "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/semantic-release/node_modules/emoji-regex": {
@@ -13815,20 +13778,6 @@
         "node": ">=18.18.0"
       }
     },
-    "node_modules/semantic-release/node_modules/import-from-esm": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-2.0.0.tgz",
-      "integrity": "sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "import-meta-resolve": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18.20"
-      }
-    },
     "node_modules/semantic-release/node_modules/indent-string": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
@@ -13874,19 +13823,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/semantic-release/node_modules/meow": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semantic-release/node_modules/normalize-package-data": {
@@ -14164,36 +14100,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/semver-diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-5.0.0.tgz",
-      "integrity": "sha512-0HbGtOm+S7T6NGQ/pxJSJipJvc4DK3FcRVMRkhsIwJDJ4Jcz5DQC1cPPzB5GhzyHjwttW878HaWQq46CkL3cqg==",
-      "deprecated": "Deprecated as the semver package now supports this built-in.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semver-diff/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/semver-regex": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
     "@semantic-release/changelog": "^6.0.3",
-    "@semantic-release/commit-analyzer": "^12.0.0",
+    "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/git": "^10.0.1",
     "ajv": "^8.14.0",
     "amex-jest-preset": "^7.0.0",
@@ -98,7 +98,7 @@
     "jest": "^29.7.0",
     "lockfile-lint": "^4.13.2",
     "prettier": "^3.2.5",
-    "semantic-release": "^25.0.2",
+    "semantic-release": "^25.0.3",
     "typescript": "^5.4.5"
   },
   "release": {


### PR DESCRIPTION
## Description
Prepare a workflow that can be used with npm's new trusted publisher system.

## Motivation and Context
This system uses OIDC and is more secure (and requires less maintenance) than generating a 90 day token

https://docs.npmjs.com/trusted-publishers

## How Has This Been Tested?
CI change, all tests green.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [x] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Jest-Image-Snapshot?
This package will be releasable again!
