### PR TITLE
fix(deps): remove unused dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@babel/eslint-parser": "^7.28.5",
         "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
         "@eslint/compat": "^2.0.0",
-        "@eslint/eslintrc": "^3.3.3",
         "@eslint/js": "^9.39.2",
         "@eslint/markdown": "^7.5.1",
         "@stylistic/eslint-plugin": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@babel/eslint-parser": "^7.28.5",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
     "@eslint/compat": "^2.0.0",
-    "@eslint/eslintrc": "^3.3.3",
     "@eslint/js": "^9.39.2",
     "@eslint/markdown": "^7.5.1",
     "@stylistic/eslint-plugin": "^5.7.0",


### PR DESCRIPTION
## Context / Solution

`@eslint/eslintrc` was added during initial eslint 9 migration, but it is not actually used in this repo